### PR TITLE
fix: [Issue #24] 特徴量配列の順序不一致（学習時と推論時）の解消

### DIFF
--- a/src/data/frontend_calendar.json
+++ b/src/data/frontend_calendar.json
@@ -2,141 +2,141 @@
   {
     "date": "2026/02/27",
     "type": "forecast",
-    "score": 99,
+    "score": 61,
     "weather": "sunny",
     "tide": "長潮",
     "marine": {
-      "temp": 8.5,
-      "transparency": 1.5,
-      "wave": 2.8,
-      "salinity": 26.4
+      "temp": 10.0,
+      "transparency": 2.9,
+      "wave": 2.7,
+      "salinity": 30.0
     },
-    "ai_comment": "季節ごとの適水温で活性期待、適度な濁りで警戒心低下、波が高く底荒れの可能性"
+    "ai_comment": "季節ごとの適水温で活性期待、波が高く底荒れの可能性"
   },
   {
     "date": "2026/02/28",
     "type": "forecast",
-    "score": 99,
+    "score": 63,
     "weather": "sunny",
     "tide": "若潮",
     "marine": {
-      "temp": 8.8,
-      "transparency": 1.4,
+      "temp": 10.2,
+      "transparency": 2.9,
       "wave": 2.7,
-      "salinity": 24.2
+      "salinity": 30.0
     },
-    "ai_comment": "季節ごとの適水温で活性期待、適度な濁りで警戒心低下、波が高く底荒れの可能性"
+    "ai_comment": "季節ごとの適水温で活性期待、波が高く底荒れの可能性"
   },
   {
     "date": "2026/03/01",
     "type": "forecast",
-    "score": 99,
+    "score": 74,
     "weather": "sunny",
     "tide": "中潮",
     "marine": {
-      "temp": 8.7,
-      "transparency": 1.4,
+      "temp": 10.6,
+      "transparency": 3.1,
       "wave": 2.8,
-      "salinity": 24.2
+      "salinity": 30.1
     },
-    "ai_comment": "水温が低く活性低下の懸念、適度な濁りで警戒心低下、波が高く底荒れの可能性"
+    "ai_comment": "水温が低く活性低下の懸念、波が高く底荒れの可能性"
   },
   {
     "date": "2026/03/02",
     "type": "forecast",
-    "score": 99,
+    "score": 76,
     "weather": "rain",
     "tide": "中潮",
     "marine": {
-      "temp": 8.9,
-      "transparency": 1.6,
+      "temp": 11.3,
+      "transparency": 3.3,
       "wave": 2.8,
-      "salinity": 24.4
+      "salinity": 29.9
     },
-    "ai_comment": "水温が低く活性低下の懸念、適度な濁りで警戒心低下、波が高く底荒れの可能性"
+    "ai_comment": "水温が低く活性低下の懸念、波が高く底荒れの可能性"
   },
   {
     "date": "2026/03/03",
     "type": "forecast",
-    "score": 99,
+    "score": 60,
     "weather": "rain",
     "tide": "大潮",
     "marine": {
-      "temp": 8.5,
-      "transparency": 1.9,
+      "temp": 11.6,
+      "transparency": 4.3,
       "wave": 2.8,
-      "salinity": 24.2
+      "salinity": 29.9
     },
-    "ai_comment": "水温が低く活性低下の懸念、適度な濁りで警戒心低下、雨による水質変化に注意、波が高く底荒れの可能性"
+    "ai_comment": "水温が低く活性低下の懸念、雨による水質変化に注意、波が高く底荒れの可能性"
   },
   {
     "date": "2026/03/04",
     "type": "forecast",
-    "score": 99,
-    "weather": "sunny",
+    "score": 80,
+    "weather": "rain",
     "tide": "大潮",
     "marine": {
-      "temp": 8.4,
-      "transparency": 1.9,
-      "wave": 2.7,
-      "salinity": 24.8
+      "temp": 11.8,
+      "transparency": 4.2,
+      "wave": 2.8,
+      "salinity": 29.8
     },
-    "ai_comment": "水温が低く活性低下の懸念、適度な濁りで警戒心低下、波が高く底荒れの可能性"
+    "ai_comment": "水温が低く活性低下の懸念、波が高く底荒れの可能性"
   },
   {
     "date": "2026/03/05",
     "type": "forecast",
-    "score": 99,
+    "score": 83,
     "weather": "sunny",
     "tide": "大潮",
     "marine": {
-      "temp": 8.4,
-      "transparency": 1.9,
+      "temp": 12.0,
+      "transparency": 4.1,
       "wave": 2.8,
-      "salinity": 24.5
+      "salinity": 29.8
     },
-    "ai_comment": "水温が低く活性低下の懸念、適度な濁りで警戒心低下、波が高く底荒れの可能性"
+    "ai_comment": "季節ごとの適水温で活性期待、波が高く底荒れの可能性"
   },
   {
     "date": "2026/03/06",
     "type": "forecast",
-    "score": 99,
+    "score": 74,
     "weather": "sunny",
     "tide": "大潮",
     "marine": {
-      "temp": 8.5,
-      "transparency": 1.9,
+      "temp": 12.3,
+      "transparency": 4.0,
       "wave": 2.8,
-      "salinity": 24.5
+      "salinity": 29.7
     },
-    "ai_comment": "水温が低く活性低下の懸念、適度な濁りで警戒心低下、波が高く底荒れの可能性"
+    "ai_comment": "季節ごとの適水温で活性期待、波が高く底荒れの可能性"
   },
   {
     "date": "2026/03/07",
     "type": "forecast",
-    "score": 99,
+    "score": 73,
     "weather": "rain",
     "tide": "中潮",
     "marine": {
-      "temp": 8.6,
-      "transparency": 1.4,
+      "temp": 12.4,
+      "transparency": 3.9,
       "wave": 2.8,
-      "salinity": 24.1
+      "salinity": 29.5
     },
-    "ai_comment": "水温が低く活性低下の懸念、適度な濁りで警戒心低下、波が高く底荒れの可能性"
+    "ai_comment": "季節ごとの適水温で活性期待、波が高く底荒れの可能性"
   },
   {
     "date": "2026/03/08",
     "type": "forecast",
-    "score": 99,
+    "score": 97,
     "weather": "sunny",
     "tide": "中潮",
     "marine": {
-      "temp": 8.4,
-      "transparency": 1.6,
+      "temp": 12.6,
+      "transparency": 3.8,
       "wave": 2.8,
-      "salinity": 24.1
+      "salinity": 29.3
     },
-    "ai_comment": "水温が低く活性低下の懸念、適度な濁りで警戒心低下、波が高く底荒れの可能性"
+    "ai_comment": "季節ごとの適水温で活性期待、波が高く底荒れの可能性"
   }
 ]

--- a/src/ml/generate_calendar.py
+++ b/src/ml/generate_calendar.py
@@ -215,10 +215,10 @@ def generate_ai_calendar(num_days=10):
             f.get('daylight_hours', 8),
             get_tide_level(d_str, tide_map),
             1 if d >= datetime(2017,8,1) and d <= datetime(2025,4,30) else 0, # Kuroshio
+            month_sin, month_cos,
             last_marine['real_water_temp'], last_marine['real_salinity'], last_marine['real_do'],
             last_marine['real_cod'], last_marine['real_transparency'],
-            last_marine['real_wave_height'], last_marine['real_river_discharge'],
-            month_sin, month_cos
+            last_marine['real_wave_height'], last_marine['real_river_discharge']
         ]
         
         marine_preds = marine_model.predict(np.array([marine_features]))[0]


### PR DESCRIPTION
## 修正内容
- `src/ml/generate_calendar.py` 内の `marine_features` 配列において、`month_sin`, `month_cos` の投入順序が学習時 (`train_real_marine.py`) とずれていた重大なバグを修正しました。

## 影響・改善
配列の順番が一致したことで、AIモデルが入力数値を正しく解釈できるようになり、デタラメだった推論結果が正常化されます。

## 解決するIssue
Issue #24 を解決します。