### PR TITLE
Resolve #35: 推論ループのラグ変数更新ロジックの論理的欠陥を修正

### DIFF
--- a/src/ml/generate_calendar.py
+++ b/src/ml/generate_calendar.py
@@ -252,9 +252,11 @@ def generate_ai_calendar(num_days=10):
         score = max(5, min(100, score))
         
         # 昨日の状態を更新 (次のループ用)
-        for k in last_marine:
-            if k in p_marine: last_marine[k] = p_marine[k]
-            
+        # NOTE: Issue #35対応 - 予測値の伝播を防ぐため、海況ラグ変数は実測値固定とする
+        # for k in last_marine:
+        #     if k in p_marine: last_marine[k] = p_marine[k]
+        # → 海況のラグ変数は最初のDB実測値を維持し、予測値で上書きしない
+
         last_weather['precipitation_lag2'] = last_weather['precipitation_lag1']
         last_weather['precipitation_lag1'] = f.get('precipitation', 0)
         last_weather['avg_wind_speed_lag1'] = f.get('avg_wind_speed', 3)


### PR DESCRIPTION
🤖 **Claude Codeによる自動実装・PR作成**

## 概要
推論ループにおいて、前段モデルの予測値をラグ変数として次の日に使用することで発生していた「予測値の誤差伝播」問題を修正しました。

## 問題点
- `generate_calendar.py`の255-256行目で、海況のラグ変数(`last_marine`)を前段モデルの予測値(`p_marine`)で上書きしていた
- これにより「予測の予測の予測...」が連鎖し、誤差が雪だるま式に増大
- 特に2日目以降の予測精度が急速に悪化していた

## 改善内容
- 海況のラグ変数を予測値で上書きするロジックをコメントアウト
- 最初のDB実測値を固定で使い続けるように変更
- これにより予測値の累積伝播を防止

## 期待される効果
- 10日間予測の後半（7-10日目）の信頼性が向上
- DOや波高などの予測精度が低いパラメータの累積誤差が軽減
- より安定した長期予測が可能に

## 変更ファイル
- `src/ml/generate_calendar.py`: ラグ変数更新ロジックを修正

## テスト結果
- ✅ Python構文チェック: 正常
- ✅ カレンダー生成スクリプト実行: 正常
- ✅ 出力ファイル生成: 正常 (`src/data/frontend_calendar.json`)

Closes #35